### PR TITLE
Built in HTTPs support + a bugfix on mime types detection that prevents uploading assets to Cloud Storage

### DIFF
--- a/webapp/protected/components/CGFileHelper.php
+++ b/webapp/protected/components/CGFileHelper.php
@@ -5,10 +5,12 @@
  * environment. Here we use some code which can deal with Google Cloud Storage instead of local file system,
  * for more info see this help from Google: https://developers.google.com/appengine/docs/php/googlestorage/
  *
- * @author Qiang Xue <qiang.xue@gmail.com>
- * @link http://www.yiiframework.com/
+ * @author    Qiang Xue <qiang.xue@gmail.com>
+ * @author    Dzhuneyt <dzhuneyt@dzhuneyt.com>
+ *
+ * @link      http://www.yiiframework.com/
  * @copyright 2008-2013 Yii Software LLC
- * @license http://www.yiiframework.com/license/
+ * @license   http://www.yiiframework.com/license/
  */
 
 /**
@@ -349,12 +351,16 @@ class CGFileHelper
      * @param string $src
      * @param string $dst gs://bucket/dir1/dir2/file like path
      */
-    private static function gCopy($src, $dst)
-    {
-        $file = basename($dst);
-        $options = [ 'gs' => [ 'Content-Type' => self::getMimeType($file) , 'acl' => 'public-read']];
-        $ctx = stream_context_create($options);
-        copy($src,$dst,$ctx);
+    private static function gCopy ( $src, $dst ) {
+        $file      = basename( $dst );
+        $mimeType  = self::getMimeType( $file );
+        $gsOptions = [ 'acl' => 'public-read' ];
+        if( $mimeType ) {
+            $gsOptions['Content-Type'] = $mimeType;
+        }
+        $options = [ 'gs' => $gsOptions ];
+        $ctx     = stream_context_create( $options );
+        copy( $src, $dst, $ctx );
     }
 
 }

--- a/webapp/protected/config/main.php
+++ b/webapp/protected/config/main.php
@@ -52,7 +52,7 @@ return array(
             // note the bucket name at the end, should be the same as in basePath above
             'baseUrl'=>ENV_DEV
                     ? '/assets'                                            // baseUrl for development App Engine
-                    : 'http://commondatastorage.googleapis.com/yii-assets' // baseUrl for production App Engine
+                    : '//commondatastorage.googleapis.com/yii-assets' // baseUrl for production App Engine
 
         ),
         'request'=>array(


### PR DESCRIPTION
- By default all apps deployed get a HTTPs based `*.appspot.com` (also if you map a custom domain with a HTTPs certificate), which fails to load any assets inside the browser because browsers have a strict policy regarding loading scripts and styles from non-secure sources inside secure web pages. The prefix for all published assets was hardcoded to http://commondatastorage.googleapis.com/ instead of being aware of the protocol of the website being viewed. This is why I have removed the protocol from main.php.
- As for the second fix, related to mime types, `self::getMimeType()` was often returning null value and null value is not accepted by the Google Cloud Storage APIs for this header. There is an error returned in this case. I've encountered this issue while trying to publish an asset directory that contained assets with non-common file extensions like .scss (the function can not automatically guess the mime type from that file extension).
